### PR TITLE
Allow setCoordiantes(Position coordinates) in KMLPoint

### DIFF
--- a/src/gov/nasa/worldwind/ogc/kml/KMLPoint.java
+++ b/src/gov/nasa/worldwind/ogc/kml/KMLPoint.java
@@ -62,6 +62,11 @@ public class KMLPoint extends KMLAbstractGeometry
     {
         return this.coordinates;
     }
+    
+    public void setCoordinates(Position coordinates)
+    {
+		this.coordinates = coordinates;
+    }
 
     protected void setCoordinates(Position.PositionList coordsList)
     {


### PR DESCRIPTION
KMLPoint#coordinates is Position, not Position.PositionList, and the setter method needs to be accessed from outside the package